### PR TITLE
Treat HeaterCooler as AC_UNIT if it `config.showHeaterCoolerAsACUnit` is set

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -78,6 +78,10 @@
         "title": "Use beta cloud server",
         "type": "boolean",
         "default": false
+      },
+      "showHeaterCoolerAsACUnit": {
+        "title": "Force Heater-Cooler devices to show as AC_UNIT",
+        "type": "boolean"
       }
     }
   },
@@ -197,7 +201,12 @@
           "type": "help",
           "helpvalue": "<h5><B>Beta Cloud</b></h5><em class='primary-text'>Used for cloud server testing only.  Change plugin cloud endpoint to beta test server.</em>"
         },
-        "betaServer"
+        "betaServer",
+        {
+          "type": "help",
+          "helpvalue": "<h5><B>Force Heater-Cooler devices to show as AC_UNIT</b></h5><em class='primary-text'>This makes heater cooler advertise as an air conditioning unit.</em>"
+        },
+        "showHeaterCoolerAsACUnit"
       ]
     }
   ]

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -15,6 +15,7 @@ export interface PluginConfig extends PlatformConfig {
   accessorySerialFilter?: Array<string>;
   forceFahrenheit?: boolean;
   betaServer?: boolean;
+  showHeaterCoolerAsACUnit?: boolean;
 }
 
 export interface Instance {

--- a/src/types/heater-cooler.spec.ts
+++ b/src/types/heater-cooler.spec.ts
@@ -84,7 +84,7 @@ describe('heaterCooler', () => {
       expect(response.attributes.thermostatTemperatureUnit).toBeDefined();
       // await sleep(10000)
     });
-    it('heaterCooler ac', async () => {
+    it('heaterCooler ac as thermostat', async () => {
       const response: any = heaterCooler.sync(heaterCoolerAC);
       expect(response).toBeDefined();
       expect(response.type).not.toBe('action.devices.types.AC_UNIT');
@@ -106,6 +106,30 @@ describe('heaterCooler', () => {
       expect(response.attributes.availableThermostatModes).not.toContain('auto');
       expect(response.attributes.thermostatTemperatureUnit).toBeDefined();
       // await sleep(10000)
+    });
+    it('heaterCooler ac as ac_unit', async () => {
+      const hap = new Hap(socketMock, log, '031-45-154', { ...config, showHeaterCoolerAsACUnit: true });
+      const heaterCooler = new HeaterCooler(hap);
+      const response: any = heaterCooler.sync(heaterCoolerAC);
+      expect(response).toBeDefined();
+      expect(response.type).toBe('action.devices.types.AC_UNIT');
+      expect(response.type).not.toBe('action.devices.types.THERMOSTAT');
+      expect(response.traits).toContain('action.devices.traits.TemperatureSetting');
+      expect(response.traits).toContain('action.devices.traits.OnOff');
+      expect(response.traits).toContain('action.devices.traits.FanSpeed');
+      expect(response.traits).not.toContain('action.devices.traits.Brightness');
+      expect(response.traits).not.toContain('action.devices.traits.ColorSetting');
+      expect(response.attributes).toBeDefined();
+      expect(response.attributes.commandOnlyOnOff).toBe(false);
+      expect(response.attributes.queryOnlyOnOff).toBe(false);
+      expect(response.attributes.supportsFanSpeedPercent).toBe(true);
+      expect(response.attributes.availableThermostatModes).toBeDefined();
+      expect(response.attributes.availableThermostatModes).toContain('off');
+      expect(response.attributes.availableThermostatModes).toContain('heat');
+      expect(response.attributes.availableThermostatModes).toContain('cool');
+      expect(response.attributes.availableThermostatModes).toContain('heatcool');
+      expect(response.attributes.availableThermostatModes).not.toContain('auto');
+      expect(response.attributes.thermostatTemperatureUnit).toBeDefined();
     });
   });
 

--- a/src/types/heater-cooler.ts
+++ b/src/types/heater-cooler.ts
@@ -37,10 +37,9 @@ export class HeaterCooler extends ghToHap implements ghToHap_t {
       queryOnlyOnOff: false,
     };
 
-    const type = 'action.devices.types.THERMOSTAT';
+    const type = this.hap.config.showHeaterCoolerAsACUnit ? 'action.devices.types.AC_UNIT' : 'action.devices.types.THERMOSTAT';
 
     if (service.serviceCharacteristics.find(x => x.uuid === Characteristic.RotationSpeed)) {
-      // type = 'action.devices.types.AC_UNIT';
       traits.push('action.devices.traits.FanSpeed');
       attributes.supportsFanSpeedPercent = true;
     }


### PR DESCRIPTION
## :gear: Release Notes

HeaterCooler will be synced as type `AC_UNIT` if `showHeaterCoolerAsACUnit` configuration option is set to `true`