### PR TITLE
Add activeThermostatMode to thermostat query response

### DIFF
--- a/src/types/thermostat.spec.ts
+++ b/src/types/thermostat.spec.ts
@@ -82,6 +82,7 @@ describe('thermostat', () => {
 
       expect(response).toBeDefined();
       expect(response.online).toBeDefined();
+      expect(response.activeThermostatMode).toBeDefined();
       expect(response.thermostatMode).toBeDefined();
       expect(response.thermostatTemperatureSetpoint).toBeDefined();
       expect(response.thermostatTemperatureAmbient).toBeDefined();
@@ -93,6 +94,7 @@ describe('thermostat', () => {
 
       expect(response).toBeDefined();
       expect(response.online).toBeDefined();
+      expect(response.activeThermostatMode).toBeDefined();
       expect(response.thermostatMode).toBeDefined();
       expect(response.thermostatTemperatureAmbient).toBeDefined();
       // await sleep(10000)
@@ -459,6 +461,27 @@ const thermostatTemp: ServiceType = {
     {
       aid: 13,
       iid: 11,
+      uuid: Characteristic.CurrentHeatingCoolingState,
+      type: 'CurrentHeatingCoolingState',
+      serviceType: 'CurrentHeatingCoolingState',
+      serviceName: 'Shed Light',
+      description: 'Configured Name',
+      value: 1,
+      format: 'string',
+      perms: ['ev', 'pr', 'pw'],
+      unit: undefined,
+      maxValue: undefined,
+      minValue: undefined,
+      minStep: undefined,
+      canRead: true,
+      canWrite: true,
+      ev: true,
+      setValue,
+      getValue,
+    },
+    {
+      aid: 13,
+      iid: 11,
       uuid: Characteristic.TargetHeatingCoolingState,
       type: 'TargetHeatingCoolingState',
       serviceType: 'TargetHeatingCoolingState',
@@ -601,6 +624,27 @@ const thermostatNoHeat: ServiceType = {
       uuid: '000000B0-0000-1000-8000-0026BB765291',
       type: 'ConfiguredName',
       serviceType: 'Active',
+      serviceName: 'Shed Light',
+      description: 'Configured Name',
+      value: 1,
+      format: 'string',
+      perms: ['ev', 'pr', 'pw'],
+      unit: undefined,
+      maxValue: undefined,
+      minValue: undefined,
+      minStep: undefined,
+      canRead: true,
+      canWrite: true,
+      ev: true,
+      setValue,
+      getValue,
+    },
+    {
+      aid: 13,
+      iid: 11,
+      uuid: Characteristic.CurrentHeatingCoolingState,
+      type: 'CurrentHeatingCoolingState',
+      serviceType: 'CurrentHeatingCoolingState',
       serviceName: 'Shed Light',
       description: 'Configured Name',
       value: 1,

--- a/src/types/thermostat.ts
+++ b/src/types/thermostat.ts
@@ -38,11 +38,14 @@ export class Thermostat extends ghToHap implements ghToHap_t {
   }
 
   query(service: ServiceType) {
+    const currentHeatingCoolingState: number = Number(service.serviceCharacteristics.find(x => x.uuid === Characteristic.CurrentHeatingCoolingState).value);
+    const activeThermostatMode = ['off', 'heat', 'cool'][currentHeatingCoolingState];
     const targetHeatingCoolingState: number = Number(service.serviceCharacteristics.find(x => x.uuid === Characteristic.TargetHeatingCoolingState).value);
     const thermostatMode = ['off', 'heat', 'cool', 'auto'][targetHeatingCoolingState];
 
     const response = {
       online: true,
+      activeThermostatMode,
       thermostatMode,
       thermostatTemperatureSetpoint: service.serviceCharacteristics.find(x => x.uuid === Characteristic.TargetTemperature).value,
       thermostatTemperatureAmbient: service.serviceCharacteristics.find(x => x.uuid === Characteristic.CurrentTemperature).value,


### PR DESCRIPTION
## :recycle: Current situation

_Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets)._

In the Google Home app, when a Nest Thermostat is either heating or cooling the device box is highlighted orange or blue to indicate actively heating or cooling. Custom thermostat plugins do not show colors based on whether the device is actively heating/cooling.

## :bulb: Proposed solution

_Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?_

Add `activeThermostatMode` based on Google Home developer docs (https://developers.home.google.com/cloud-to-cloud/traits/temperaturesetting)

## :gear: Release Notes

_Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features._

Custom thermostat plugins will now show active heating or cooling state in the Google Home app.

## :heavy_plus_sign: Additional Information

_If applicable, provide additional context in this section._

### Testing

_Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?_

Unit tests for thermostat type were updated to include `activeThermostatMode` in the expected response.

### Reviewer Nudging

_Where should the reviewer start? what is a good entry point?_

Run a custom plugin for a thermostat and just statically set the state in the Google Home app.
