### PR TITLE
Implement channel/input selection of Television device

### DIFF
--- a/src/hap.ts
+++ b/src/hap.ts
@@ -195,7 +195,7 @@ export class Hap {
    */
   async buildSyncResponse(): Promise<SmartHomeV1SyncDevices[]> {
     const devices = this.services.filter((service) =>
-      this.types?.[service.type]?.sync
+      this.types?.[service.type]?.sync,
     ).map((service) => {
       // if (!this.types[service.type]) {
       //   // this.log.debug(`Unsupported service type ${service.type}`);
@@ -390,7 +390,9 @@ export class Hap {
 
     for (const uniqueId of pendingStateReport) {
       const service = this.services.find(x => x.uniqueId === uniqueId);
-      if (!this.types?.[service.type]?.query) continue;
+      if (!this.types?.[service.type]?.query) {
+        continue;
+      }
       states[service.uniqueId] = this.types[service.type].query(service);
     }
 
@@ -405,7 +407,7 @@ export class Hap {
       return;
     }
     this.services.filter((service) => 
-      this.types?.[service.type]?.query
+      this.types?.[service.type]?.query,
     ).map((service) => {
       // if (!this.types[service.type]) {
       //   return;

--- a/src/hap.ts
+++ b/src/hap.ts
@@ -201,6 +201,7 @@ export class Hap {
       //   // this.log.debug(`Unsupported service type ${service.type}`);
       //   return;
       // }
+      // // console.log('buildSyncResponse', service);
       return this.types[service.type].sync(service);
     });
     return devices;

--- a/src/hap.ts
+++ b/src/hap.ts
@@ -40,6 +40,8 @@ export class Hap {
 
   public ready: boolean;
 
+  private dummy = () => {};
+  
   /* GSH Supported types */
   types = {
     Door: new Door(),
@@ -53,11 +55,13 @@ export class Hap {
     Outlet: new Switch('action.devices.types.OUTLET'),
     SecuritySystem: new SecuritySystem(),
     Switch: new Switch('action.devices.types.SWITCH'),
-    Television: new Television(),
+    Television: new Television(this),
     TemperatureSensor: new TemperatureSensor(this),
     Thermostat: new Thermostat(this),
     Window: new Window(),
     WindowCovering: new WindowCovering(),
+    Speaker: this.dummy,
+    InputSource: this.dummy,
   };
 
   /* event tracking */
@@ -87,6 +91,8 @@ export class Hap {
     Characteristic.CurrentRelativeHumidity,
     Characteristic.SecuritySystemTargetState,
     Characteristic.SecuritySystemCurrentState,
+    Characteristic.ActiveIdentifier,
+    Characteristic.Mute,
   ];
 
   instanceBlacklist: Array<string> = [];
@@ -188,12 +194,13 @@ export class Hap {
    * Build Google SYNC intent payload
    */
   async buildSyncResponse(): Promise<SmartHomeV1SyncDevices[]> {
-    const devices = this.services.map((service) => {
-      if (!this.types[service.type]) {
-        // this.log.debug(`Unsupported service type ${service.type}`);
-        return;
-      }
-      // console.log('buildSyncResponse', service);
+    const devices = this.services.filter((service) =>
+      this.types?.[service.type]?.sync
+    ).map((service) => {
+      // if (!this.types[service.type]) {
+      //   // this.log.debug(`Unsupported service type ${service.type}`);
+      //   return;
+      // }
       return this.types[service.type].sync(service);
     });
     return devices;
@@ -245,7 +252,7 @@ export class Hap {
     for (const command of commands) {
       for (const device of command.devices) {
         const service = this.services.find(x => x.uniqueId === device.id);
-        this.log.debug(`Processing command ${command.execution[0].command} for ${device.id} and ${service}`);
+        this.log.debug(`Processing command ${command.execution[0].command} for ${device.id} and ${service.serviceName}`);
         if (service) {
           // check if two factor auth is required, and if we have it
           if (this.config.twoFactorAuthPin && this.types[service.type].twoFactorRequired
@@ -382,6 +389,7 @@ export class Hap {
 
     for (const uniqueId of pendingStateReport) {
       const service = this.services.find(x => x.uniqueId === uniqueId);
+      if (!this.types?.[service.type]?.query) continue;
       states[service.uniqueId] = this.types[service.type].query(service);
     }
 
@@ -395,10 +403,12 @@ export class Hap {
     if (!this.services.length) {
       return;
     }
-    this.services.map((service) => {
-      if (!this.types[service.type]) {
-        return;
-      }
+    this.services.filter((service) => 
+      this.types?.[service.type]?.query
+    ).map((service) => {
+      // if (!this.types[service.type]) {
+      //   return;
+      // }
       return states[service.uniqueId] = this.types[service.type].query(service);
     });
     return await this.sendStateReport(states);

--- a/src/types/television.spec.ts
+++ b/src/types/television.spec.ts
@@ -1,7 +1,42 @@
 import { CharacteristicType, ServiceType } from '@homebridge/hap-client';
+import { Hap } from '../hap';
 import { Television } from './television';
+import { PluginConfig } from '../interfaces';
 
-const television = new Television();
+import { Log } from '../logger';
+
+import { Thermostat } from './thermostat';
+
+class socketMock {
+  on(event: string, callback: any) {
+    if (event === 'websocket-status') {
+      callback('websocket-status');
+    }
+    if (event === 'json') {
+      callback({ serverMessage: 'serverMessage' });
+    }
+  }
+
+  sendJson(data: any) {
+    // eslint-disable-next-line no-console
+    console.log('sendJson', data);
+  }
+}
+
+const config: PluginConfig = {
+  name: 'Google Smart Home',
+  token: '1234567890',
+  notice: 'Keep your token a secret!',
+  debug: false,
+  platform: 'google-smarthome',
+  twoFactorAuthPin: '123-456',
+};
+
+const log = new Log(console, true);
+
+const hap = new Hap(socketMock, log, '031-45-154', config, {});
+
+const television = new Television(hap);
 
 describe('television', () => {
   describe('sync message', () => {

--- a/src/types/television.spec.ts
+++ b/src/types/television.spec.ts
@@ -1,11 +1,10 @@
 import { CharacteristicType, ServiceType } from '@homebridge/hap-client';
 import { Hap } from '../hap';
-import { Television } from './television';
 import { PluginConfig } from '../interfaces';
+import { Television } from './television';
 
 import { Log } from '../logger';
 
-import { Thermostat } from './thermostat';
 
 class socketMock {
   on(event: string, callback: any) {
@@ -41,13 +40,21 @@ const television = new Television(hap);
 describe('television', () => {
   describe('sync message', () => {
     it('television with On/Off only', async () => {
+      const attributes = {
+        'availableApplications': [],
+        'commandOnlyOnOff': false,
+        'queryOnlyOnOff': false,
+        'supportActivityState': false,
+        'supportPlaybackState': false,
+        'transportControlSupportedCommands': [],
+      };
       const response: any = television.sync(televisionServiceOnOff);
       expect(response).toBeDefined();
       expect(response.type).toBe('action.devices.types.TV');
       expect(response.traits).toContain('action.devices.traits.OnOff');
       expect(response.traits).not.toContain('action.devices.traits.Brightness');
       expect(response.traits).not.toContain('action.devices.traits.ColorSetting');
-      expect(response.attributes).not.toBeDefined();
+      expect(response.attributes).toEqual(attributes);
       // await sleep(10000)
     });
   });

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -1,7 +1,7 @@
 import { ServiceType } from '@homebridge/hap-client';
 import { SmartHomeV1ExecuteRequestCommands, SmartHomeV1ExecuteResponseCommands } from 'actions-on-google';
 import { Hap } from '../hap';
-import { Service, Characteristic } from '../hap-types';
+import { Characteristic, Service } from '../hap-types';
 import { ghToHap, ghToHap_t } from './ghToHapTypes';
 
 export class Television extends ghToHap implements ghToHap_t {
@@ -12,56 +12,56 @@ export class Television extends ghToHap implements ghToHap_t {
   }
 
   private instances = {};
-  
+
   sync(service: ServiceType) {
     if (!this.instances[service.uniqueId]) {
       this.instances[service.uniqueId] = {
-	Mute: [],
-	volumeSelector: [],
-	channels: [],
-	lastChannel: undefined,
-	inputs: [],
+        Mute: [],
+        volumeSelector: [],
+        channels: [],
+        lastChannel: undefined,
+        inputs: [],
       };
     }
     const instance = this.instances[service.uniqueId];
-      
+
     // console.log(`${service.type}: ${service.instance.username}, aid:${service.aid}, iid:${service.iid}, name: ${service.serviceName}`);
     const x = this.hap.services.filter(x => x.aid === service.aid && x.instance.username === service.instance.username) ?? [];
-    
+
     for (const speaker of x.filter(x => x.uuid === Service.Speaker)) {
       instance.Mute = [];
       for (const c of speaker.serviceCharacteristics.filter(x => x.uuid === Characteristic.Mute)) {
-	// console.log(`  ${speaker.type}: ${speaker.serviceName}, ${c.type}: ${c.serviceName}`);
-	instance.Mute.push(c);
+        // console.log(`  ${speaker.type}: ${speaker.serviceName}, ${c.type}: ${c.serviceName}`);
+        instance.Mute.push(c);
       }
       instance.volumeSelector = [];
       for (const c of speaker.serviceCharacteristics.filter(x => x.uuid === Characteristic.VolumeSelector)) {
-	// console.log(`  ${speaker.type}: ${speaker.serviceName}, ${c.type}: ${c.serviceName}`);
-	instance.volumeSelector.push(c);
+        // console.log(`  ${speaker.type}: ${speaker.serviceName}, ${c.type}: ${c.serviceName}`);
+        instance.volumeSelector.push(c);
       }
     }
-    
+
     instance.channels = [];
     instance.inputs = [];
     for (const input of x.filter(x => x.uuid === Service.InputSource)) {    // service.linked is better?
       const cname = input.serviceCharacteristics.find(x => x.uuid === Characteristic.ConfiguredName)?.value as string;
       const c = {
-	serviceName: input.serviceName,
-	Identifier: input.serviceCharacteristics.find(x => x.uuid === Characteristic.Identifier)?.value,
-	InputSourceType: input.serviceCharacteristics.find(x => x.uuid === Characteristic.InputSourceType)?.value,
+        serviceName: input.serviceName,
+        Identifier: input.serviceCharacteristics.find(x => x.uuid === Characteristic.Identifier)?.value,
+        InputSourceType: input.serviceCharacteristics.find(x => x.uuid === Characteristic.InputSourceType)?.value,
       } as any;
       if (cname.substring(0, 10) === 'Station - ') {
-	c.ConfiguredName = cname.substring(10);
-	instance.channels.push(c);
+        c.ConfiguredName = cname.substring(10);
+        instance.channels.push(c);
       } else {
-	c.ConfiguredName = cname;
-	instance.inputs.push(c);
+        c.ConfiguredName = cname;
+        instance.inputs.push(c);
       }
     }
     // console.log(`${service.type}: ${service.instance.username}, aid:${service.aid}, iid:${service.iid}, name: ${service.serviceName}`);
     // console.log(`channels: ${JSON.stringify(this.instances[service.uniqueId].channels, null, 2)}`);
     // console.log(`inputs: ${JSON.stringify(this.instances[service.uniqueId].inputs, null, 2)}`);
-      
+
     const traits = [
       'action.devices.traits.OnOff',
       'action.devices.traits.MediaState',
@@ -73,18 +73,18 @@ export class Television extends ghToHap implements ghToHap_t {
     const attributes = {
       commandOnlyOnOff: false,	//OnOff
       queryOnlyOnOff: false,
-      supportActivityState: false,//MediaState
+      supportActivityState: false, //MediaState
       supportPlaybackState: false,
     } as any;
     attributes.availableApplications = [];
     attributes.transportControlSupportedCommands = [];
     if (service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey)) {
       attributes.transportControlSupportedCommands = [
-	'STOP',
-	'RESUME',
-	'PAUSE',
-	'NEXT',
-	'PREVIOUS',
+        'STOP',
+        'RESUME',
+        'PAUSE',
+        'NEXT',
+        'PREVIOUS',
       ];
     }
     if (instance.volumeSelector.find(x => x.uuid === Characteristic.VolumeSelector)) {
@@ -98,17 +98,18 @@ export class Television extends ghToHap implements ghToHap_t {
       attributes.commandOnlyChannels = true;
       attributes.availableChannels = [];
       for (const c of instance.channels) {
-	let n = [c.ConfiguredName], a;
-	if (a = this.hap.config.channelAlias.find(x => x.channel === c.ConfiguredName)) {
-	  for (const x of a.alias) {
-	    n.push(x);
-	  }
-	}
-	attributes.availableChannels.push({
-	  key: c.serviceName,
-	  names: n,
-	  number: `${c.Identifier + 1}`,
-	});
+        const n = [c.ConfiguredName];
+        const a = this.hap.config.channelAlias.find(x => x.channel === c.ConfiguredName);
+        if (a) {
+          for (const x of a.alias) {
+            n.push(x);
+          }
+        }
+        attributes.availableChannels.push({
+          key: c.serviceName,
+          names: n,
+          number: `${c.Identifier + 1}`,
+        });
       }
     }
     if (instance.inputs.length > 0) {
@@ -116,28 +117,28 @@ export class Television extends ghToHap implements ghToHap_t {
       attributes.commandOnlyInputSelector = false;
       attributes.orderedInputs = true;
       attributes.availableInputs = [{
-	key: "_tv",	//dummy for stations
-	names: [
-	  {
-	    lang: "en",
-	    name_synonym: [
-	      "_tv",
-	    ]
-	  }
-	]
+        key: '_tv',	//dummy for stations
+        names: [
+          {
+            lang: 'en',
+            name_synonym: [
+              '_tv',
+            ],
+          },
+        ],
       }];
       for (const c of instance.inputs) {
-	attributes.availableInputs.push({
-	  key: c.serviceName,
-	  names: [
-	    {
-	      lang: "en",
-	      name_synonym: [
-		c.ConfiguredName,
-	      ]
-	    }
-	  ],
-	});
+        attributes.availableInputs.push({
+          key: c.serviceName,
+          names: [
+            {
+              lang: 'en',
+              name_synonym: [
+                c.ConfiguredName,
+              ],
+            },
+          ],
+        });
       }
     }
     // console.log(JSON.stringify(traits, null, 2));
@@ -151,7 +152,7 @@ export class Television extends ghToHap implements ghToHap_t {
   }
 
   query(service: ServiceType) {
-    let c;
+
     const instance = this.instances[service.uniqueId];
     const response = {
       on: !!service.serviceCharacteristics.find(x => x.uuid === Characteristic.Active).value,
@@ -160,21 +161,23 @@ export class Television extends ghToHap implements ghToHap_t {
     if (instance.volumeSelector.find(x => x.uuid === Characteristic.VolumeSelector)) {
       response.currentVolume = 10;
     }
-    if (c = instance.Mute.find(x => x.uuid === Characteristic.Mute)) {
-      response.isMuted =  c.value ? true : false;
+    const cMute = instance.Mute.find(x => x.uuid === Characteristic.Mute);
+    if (cMute) {
+      response.isMuted = cMute.value ? true : false;
     }
-    if (c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier)) {
-      let i;
-      response.currentInput =  "_tv";
-      if (i = instance.inputs.find(x => x.Identifier === c.value)) {
-	response.currentInput =  i.serviceName;
+    const cActive = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier);
+    if (cActive) {
+      response.currentInput = '_tv';
+      const i = instance.channels.find(x => x.Identifier === cActive.value);
+      if (i) {
+        response.currentInput = i.serviceName;
       }
     }
     // console.log(service.serviceName, response);
     // console.log(`${JSON.stringify(instance, null, 2)}`);
-    
+
     return response;
-    
+
     // return {
     //   on: !!service.serviceCharacteristics.find(x => x.uuid === Characteristic.Active).value,
     //   online: true,
@@ -195,102 +198,106 @@ export class Television extends ghToHap implements ghToHap_t {
         await instance.Mute.find(x => x.uuid === Characteristic.Mute).setValue(command.execution[0].params.mute ? 1 : 0);
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
-   // case ('action.devices.commands.setVolume'): {	// No proper characteristic
-   // }
+      // case ('action.devices.commands.setVolume'): {	// No proper characteristic
+      // }
       case ('action.devices.commands.volumeRelative'): {
-	// Characteristic.VolumeSelector.INCREMENT = 0;
-	// Characteristic.VolumeSelector.DECREMENT = 1;
+        // Characteristic.VolumeSelector.INCREMENT = 0;
+        // Characteristic.VolumeSelector.DECREMENT = 1;
         await instance.volumeSelector.find(x => x.uuid === Characteristic.VolumeSelector).setValue(command.execution[0].params.relativeSteps < 0 ? 1 : 0);
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       case ('action.devices.commands.selectChannel'): {
-	let c;
-	if (command.execution[0].params?.channelCode) {
-	  const code = command.execution[0].params.channelCode;
-	  if (c = instance.channels.find(x => x.serviceName === code)) {
-	    await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c.Identifier);
+
+        if (command.execution[0].params?.channelCode) {
+          const code = command.execution[0].params.channelCode;
+          const c = instance.channels.find(x => x.serviceName === code);
+          if (c) {
+            await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c.Identifier);
             return { ids: [service.uniqueId], status: 'SUCCESS' };
-	  }
-	} else if (command.execution[0].params?.channelNumber) {
-	  const number = parseInt(command.execution[0].params.channelNumber) - 1;
-	  if (c = instance.channels.find(x => x.Identifier === number)) {
-	    await service.serviceCharacteristics.find(x => x.type === Characteristic.ActiveIdentifier).setValue(c.Identifier);
+          }
+        } else if (command.execution[0].params?.channelNumber) {
+          const number = parseInt(command.execution[0].params.channelNumber) - 1;
+          const c = instance.channels.find(x => x.Identifier === number);
+          if (c) {
+            await service.serviceCharacteristics.find(x => x.type === Characteristic.ActiveIdentifier).setValue(c.Identifier);
             return { ids: [service.uniqueId], status: 'SUCCESS' };
-	  }
-      //} else if (command.execution[0].params?.channelName) {
-	}
-	break;
+          }
+          //} else if (command.execution[0].params?.channelName) {
+        }
+        break;
       }
       case ('action.devices.commands.relativeChannel'): {
-	const change = command.execution[0].params?.relativeChannelChange;
-	const n = instance.channels.length;
-	let c = instance.lastChannel !== undefined ? instance.channels.findIndex(x => x.Identifier === instance.lastChannel) : n - 1;
-	// const d = service.serviceCharacteristics.find(x => x.uuid === Characteristic.serviceName).value;
-	// console.log(`Current channel index of ${d} is ${c}.`);
-	if (change > 0) {
-	  if (++c > n - 1)
-	    c = 0;
-	} else if (change < 0) {
-	  if (--c < 0)
-	    c = n - 1;
-	}
-	// console.log(`Updated channel index of ${d} to ${c}.`);
-	c = instance.channels[c].Identifier;
-	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
-	instance.lastChannel = c;
+        const change = command.execution[0].params?.relativeChannelChange;
+        const n = instance.channels.length;
+        let c = instance.lastChannel !== undefined ? instance.channels.findIndex(x => x.Identifier === instance.lastChannel) : n - 1;
+        // const d = service.serviceCharacteristics.find(x => x.uuid === Characteristic.serviceName).value;
+        // console.log(`Current channel index of ${d} is ${c}.`);
+        if (change > 0) {
+          if (++c > n - 1) {
+            c = 0;
+          }
+        } else if (change < 0) {
+          if (--c < 0) {
+            c = n - 1;
+          }
+        }
+        // console.log(`Updated channel index of ${d} to ${c}.`);
+        c = instance.channels[c].Identifier;
+        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
+        instance.lastChannel = c;
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       case ('action.devices.returnChannel'): {
-	let c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).value;
-	c = instance.lastChannel !== undefined ? instance.lastChannel : instance.channels[0]?.Identifier;
-	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
-	instance.lastChannel = c;
+        let c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).value;
+        c = instance.lastChannel !== undefined ? instance.lastChannel : instance.channels[0]?.Identifier;
+        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
+        instance.lastChannel = c;
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       case ('action.devices.commands.SetInput'): {
-	const input = command.execution[0].params?.newInput;
-	let c;
-	if (c = instance.inputs.find(x => x.serviceName === input)) {
-	  await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(parseInt(c.Identifier));
-          return { ids: [service.uniqueId], status: 'SUCCESS', states: {currentInput: c.serviceName} };
-	}
-	break;
+        const input = command.execution[0].params?.newInput;
+        const c = instance.inputs.find(x => x.serviceName === input);
+        if (c) {
+          await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(parseInt(c.Identifier));
+          return { ids: [service.uniqueId], status: 'SUCCESS', states: { currentInput: c.serviceName } };
+        }
+        break;
       }
       case ('action.devices.commands.NextInput'): {
-	let c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).value as number;
-	let n = instance.inputs.length;
-	if (instance.channels.find(x => x.Identifier === c)) {
-	  c = -1;
-	} else {
-	  c = instance.inputs.findIndex(x => x.Identifier === c);
-	}
-	// const d = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Name).value;
-	// console.log(`Current input index of ${d} is ${c}.`);
-	if (++c > n - 1) {
-	  c = 0;
-	}
-	// console.log(`Updated input index of ${d} to ${c}.`);
-	c = instance.inputs[c]?.Identifier;
-	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
-        return { ids: [service.uniqueId], status: 'SUCCESS', states: {currentInput: instance.inputs.find(x => x.Identifier === c).serviceName} };
+        let c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).value as number;
+        const n = instance.inputs.length;
+        if (instance.channels.find(x => x.Identifier === c)) {
+          c = -1;
+        } else {
+          c = instance.inputs.findIndex(x => x.Identifier === c);
+        }
+        // const d = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Name).value;
+        // console.log(`Current input index of ${d} is ${c}.`);
+        if (++c > n - 1) {
+          c = 0;
+        }
+        // console.log(`Updated input index of ${d} to ${c}.`);
+        c = instance.inputs[c]?.Identifier;
+        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
+        return { ids: [service.uniqueId], status: 'SUCCESS', states: { currentInput: instance.inputs.find(x => x.Identifier === c).serviceName } };
       }
       case ('action.devices.commands.PreviousInput'): {
-	let c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).value as number;
-	let n = instance.inputs.length;
-	if (instance.channels.find(x => x.Identifier === c)) {
-	  c = -1;
-	} else {
-	  c = instance.inputs.findIndex(x => x.Identifier === c);
-	}
-	// const d = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Name).value;
-	// console.log(`Current input index of ${d} is ${c}.`);
-	if (--c < 0) {
-	  c = n - 1;
-	}
-	// console.log(`Updated input index of ${d} to ${c}.`);
-	c = instance.inputs[c]?.Identifier;
-	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
-        return { ids: [service.uniqueId], status: 'SUCCESS', states: {currentInput: instance.inputs.find(x => x.Identifier === c).serviceName} };
+        let c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).value as number;
+        const n = instance.inputs.length;
+        if (instance.channels.find(x => x.Identifier === c)) {
+          c = -1;
+        } else {
+          c = instance.inputs.findIndex(x => x.Identifier === c);
+        }
+        // const d = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Name).value;
+        // console.log(`Current input index of ${d} is ${c}.`);
+        if (--c < 0) {
+          c = n - 1;
+        }
+        // console.log(`Updated input index of ${d} to ${c}.`);
+        c = instance.inputs[c]?.Identifier;
+        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
+        return { ids: [service.uniqueId], status: 'SUCCESS', states: { currentInput: instance.inputs.find(x => x.Identifier === c).serviceName } };
       }
       // Characteristic.RemoteKey.REWIND = 0;
       // Characteristic.RemoteKey.FAST_FORWARD = 1;
@@ -306,23 +313,23 @@ export class Television extends ghToHap implements ghToHap_t {
       // Characteristic.RemoteKey.PLAY_PAUSE = 11;
       // Characteristic.RemoteKey.INFORMATION = 15;
       case ('action.devices.commands.mediaStop'): {
-	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(9) // Characteristic.RemoteKey.BACK,
+        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(9); // Characteristic.RemoteKey.BACK,
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       case ('action.devices.commands.mediaResume'): {
-	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(8); // Characteristic.RemoteKey.SELECT,
+        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(8); // Characteristic.RemoteKey.SELECT,
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       case ('action.devices.commands.mediaPause'): {
-	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(11); // Characteristic.RemoteKey.PLAY_PAUSE,
+        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(11); // Characteristic.RemoteKey.PLAY_PAUSE,
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       case ('action.devices.commands.mediaNext'): {
-	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(7); // Characteristic.RemoteKey.ARROW_RIGHT,
+        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(7); // Characteristic.RemoteKey.ARROW_RIGHT,
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       case ('action.devices.commands.mediaPrevious'): {
-	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(6); // Characteristic.RemoteKey.ARROW_LEFT,
+        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(6); // Characteristic.RemoteKey.ARROW_LEFT,
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       default: { return { ids: [service.uniqueId], status: 'ERROR', debugString: `unknown command ${command.execution[0].command}` }; }

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -1,32 +1,328 @@
 import { ServiceType } from '@homebridge/hap-client';
 import { SmartHomeV1ExecuteRequestCommands, SmartHomeV1ExecuteResponseCommands } from 'actions-on-google';
-import { Characteristic } from '../hap-types';
+import { Hap } from '../hap';
+import { Service, Characteristic } from '../hap-types';
 import { ghToHap, ghToHap_t } from './ghToHapTypes';
 
 export class Television extends ghToHap implements ghToHap_t {
+  constructor(
+    private hap: Hap,
+  ) {
+    super();
+  }
+
+  private instances = {};
+  
   sync(service: ServiceType) {
+    if (!this.instances[service.uniqueId]) {
+      this.instances[service.uniqueId] = {
+	Mute: [],
+	volumeSelector: [],
+	channels: [],
+	lastChannel: undefined,
+	inputs: [],
+      };
+    }
+    const instance = this.instances[service.uniqueId];
+      
+    // console.log(`${service.type}: ${service.instance.username}, aid:${service.aid}, iid:${service.iid}, name: ${service.serviceName}`);
+    const x = this.hap.services.filter(x => x.aid === service.aid && x.instance.username === service.instance.username) ?? [];
+    
+    for (const speaker of x.filter(x => x.uuid === Service.Speaker)) {
+      instance.Mute = [];
+      for (const c of speaker.serviceCharacteristics.filter(x => x.uuid === Characteristic.Mute)) {
+	// console.log(`  ${speaker.type}: ${speaker.serviceName}, ${c.type}: ${c.serviceName}`);
+	instance.Mute.push(c);
+      }
+      instance.volumeSelector = [];
+      for (const c of speaker.serviceCharacteristics.filter(x => x.uuid === Characteristic.VolumeSelector)) {
+	// console.log(`  ${speaker.type}: ${speaker.serviceName}, ${c.type}: ${c.serviceName}`);
+	instance.volumeSelector.push(c);
+      }
+    }
+    
+    instance.channels = [];
+    instance.inputs = [];
+    for (const input of x.filter(x => x.uuid === Service.InputSource)) {    // service.linked is better?
+      const cname = input.serviceCharacteristics.find(x => x.uuid === Characteristic.ConfiguredName)?.value as string;
+      const c = {
+	serviceName: input.serviceName,
+	Identifier: input.serviceCharacteristics.find(x => x.uuid === Characteristic.Identifier)?.value,
+	InputSourceType: input.serviceCharacteristics.find(x => x.uuid === Characteristic.InputSourceType)?.value,
+      } as any;
+      if (cname.substring(0, 10) === 'Station - ') {
+	c.ConfiguredName = cname.substring(10);
+	instance.channels.push(c);
+      } else {
+	c.ConfiguredName = cname;
+	instance.inputs.push(c);
+      }
+    }
+    // console.log(`${service.type}: ${service.instance.username}, aid:${service.aid}, iid:${service.iid}, name: ${service.serviceName}`);
+    // console.log(`channels: ${JSON.stringify(this.instances[service.uniqueId].channels, null, 2)}`);
+    // console.log(`inputs: ${JSON.stringify(this.instances[service.uniqueId].inputs, null, 2)}`);
+      
+    const traits = [
+      'action.devices.traits.OnOff',
+      'action.devices.traits.MediaState',
+      //'action.devices.traits.Modes',
+      //'action.devices.traits.Toggles',
+      'action.devices.traits.AppSelector',
+      'action.devices.traits.TransportControl',
+    ];
+    const attributes = {
+      commandOnlyOnOff: false,	//OnOff
+      queryOnlyOnOff: false,
+      supportActivityState: false,//MediaState
+      supportPlaybackState: false,
+    } as any;
+    attributes.availableApplications = [];
+    attributes.transportControlSupportedCommands = [];
+    if (service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey)) {
+      attributes.transportControlSupportedCommands = [
+	'STOP',
+	'RESUME',
+	'PAUSE',
+	'NEXT',
+	'PREVIOUS',
+      ];
+    }
+    if (instance.volumeSelector.find(x => x.uuid === Characteristic.VolumeSelector)) {
+      traits.push('action.devices.traits.Volume');
+      attributes.volumeCanMuteAndUnmute = instance.Mute.find(x => x.uuid === Characteristic.Mute) ? true : false;
+      attributes.volumeMaxLevel = 20;	//Volume. Just in case for a relative operations
+      attributes.commandOnlyVolume = true;
+    }
+    if (instance.channels.length > 0) {
+      traits.push('action.devices.traits.Channel');
+      attributes.commandOnlyChannels = true;
+      attributes.availableChannels = [];
+      for (const c of instance.channels) {
+	let n = [c.ConfiguredName], a;
+	if (a = this.hap.config.channelAlias.find(x => x.channel === c.ConfiguredName)) {
+	  for (const x of a.alias) {
+	    n.push(x);
+	  }
+	}
+	attributes.availableChannels.push({
+	  key: c.serviceName,
+	  names: n,
+	  number: `${c.Identifier + 1}`,
+	});
+      }
+    }
+    if (instance.inputs.length > 0) {
+      traits.push('action.devices.traits.InputSelector');
+      attributes.commandOnlyInputSelector = false;
+      attributes.orderedInputs = true;
+      attributes.availableInputs = [{
+	key: "_tv",	//dummy for stations
+	names: [
+	  {
+	    lang: "en",
+	    name_synonym: [
+	      "_tv",
+	    ]
+	  }
+	]
+      }];
+      for (const c of instance.inputs) {
+	attributes.availableInputs.push({
+	  key: c.serviceName,
+	  names: [
+	    {
+	      lang: "en",
+	      name_synonym: [
+		c.ConfiguredName,
+	      ]
+	    }
+	  ],
+	});
+      }
+    }
+    // console.log(JSON.stringify(traits, null, 2));
+    // console.log(JSON.stringify(attributes, null, 2));
+
     return this.createSyncData(service, {
       type: 'action.devices.types.TV',
-      traits: [
-        'action.devices.traits.OnOff',
-      ],
+      traits: traits,
+      attributes: attributes,
     });
   }
 
   query(service: ServiceType) {
-    return {
+    let c;
+    const instance = this.instances[service.uniqueId];
+    const response = {
       on: !!service.serviceCharacteristics.find(x => x.uuid === Characteristic.Active).value,
       online: true,
-    };
+    } as any;
+    if (instance.volumeSelector.find(x => x.uuid === Characteristic.VolumeSelector)) {
+      response.currentVolume = 10;
+    }
+    if (c = instance.Mute.find(x => x.uuid === Characteristic.Mute)) {
+      response.isMuted =  c.value ? true : false;
+    }
+    if (c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier)) {
+      let i;
+      response.currentInput =  "_tv";
+      if (i = instance.inputs.find(x => x.Identifier === c.value)) {
+	response.currentInput =  i.serviceName;
+      }
+    }
+    // console.log(service.serviceName, response);
+    // console.log(`${JSON.stringify(instance, null, 2)}`);
+    
+    return response;
+    
+    // return {
+    //   on: !!service.serviceCharacteristics.find(x => x.uuid === Characteristic.Active).value,
+    //   online: true,
+    // };
   }
 
   async execute(service: ServiceType, command: SmartHomeV1ExecuteRequestCommands): Promise<SmartHomeV1ExecuteResponseCommands> {
+    const instance = this.instances[service.uniqueId];
     if (!command.execution.length) {
       return { ids: [service.uniqueId], status: 'ERROR', debugString: 'missing command' };
     }
     switch (command.execution[0].command) {
       case ('action.devices.commands.OnOff'): {
         await service.serviceCharacteristics.find(x => x.uuid === Characteristic.Active).setValue(command.execution[0].params.on ? 1 : 0);
+        return { ids: [service.uniqueId], status: 'SUCCESS' };
+      }
+      case ('action.devices.commands.mute'): {
+        await instance.Mute.find(x => x.uuid === Characteristic.Mute).setValue(command.execution[0].params.mute ? 1 : 0);
+        return { ids: [service.uniqueId], status: 'SUCCESS' };
+      }
+   // case ('action.devices.commands.setVolume'): {	// No proper characteristic
+   // }
+      case ('action.devices.commands.volumeRelative'): {
+	// Characteristic.VolumeSelector.INCREMENT = 0;
+	// Characteristic.VolumeSelector.DECREMENT = 1;
+        await instance.volumeSelector.find(x => x.uuid === Characteristic.VolumeSelector).setValue(command.execution[0].params.relativeSteps < 0 ? 1 : 0);
+        return { ids: [service.uniqueId], status: 'SUCCESS' };
+      }
+      case ('action.devices.commands.selectChannel'): {
+	let c;
+	if (command.execution[0].params?.channelCode) {
+	  const code = command.execution[0].params.channelCode;
+	  if (c = instance.channels.find(x => x.serviceName === code)) {
+	    await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c.Identifier);
+            return { ids: [service.uniqueId], status: 'SUCCESS' };
+	  }
+	} else if (command.execution[0].params?.channelNumber) {
+	  const number = parseInt(command.execution[0].params.channelNumber) - 1;
+	  if (c = instance.channels.find(x => x.Identifier === number)) {
+	    await service.serviceCharacteristics.find(x => x.type === Characteristic.ActiveIdentifier).setValue(c.Identifier);
+            return { ids: [service.uniqueId], status: 'SUCCESS' };
+	  }
+      //} else if (command.execution[0].params?.channelName) {
+	}
+	break;
+      }
+      case ('action.devices.commands.relativeChannel'): {
+	const change = command.execution[0].params?.relativeChannelChange;
+	const n = instance.channels.length;
+	let c = instance.lastChannel !== undefined ? instance.channels.findIndex(x => x.Identifier === instance.lastChannel) : n - 1;
+	// const d = service.serviceCharacteristics.find(x => x.uuid === Characteristic.serviceName).value;
+	// console.log(`Current channel index of ${d} is ${c}.`);
+	if (change > 0) {
+	  if (++c > n - 1)
+	    c = 0;
+	} else if (change < 0) {
+	  if (--c < 0)
+	    c = n - 1;
+	}
+	// console.log(`Updated channel index of ${d} to ${c}.`);
+	c = instance.channels[c].Identifier;
+	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
+	instance.lastChannel = c;
+        return { ids: [service.uniqueId], status: 'SUCCESS' };
+      }
+      case ('action.devices.returnChannel'): {
+	let c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).value;
+	c = instance.lastChannel !== undefined ? instance.lastChannel : instance.channels[0]?.Identifier;
+	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
+	instance.lastChannel = c;
+        return { ids: [service.uniqueId], status: 'SUCCESS' };
+      }
+      case ('action.devices.commands.SetInput'): {
+	const input = command.execution[0].params?.newInput;
+	let c;
+	if (c = instance.inputs.find(x => x.serviceName === input)) {
+	  await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(parseInt(c.Identifier));
+          return { ids: [service.uniqueId], status: 'SUCCESS', states: {currentInput: c.serviceName} };
+	}
+	break;
+      }
+      case ('action.devices.commands.NextInput'): {
+	let c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).value as number;
+	let n = instance.inputs.length;
+	if (instance.channels.find(x => x.Identifier === c)) {
+	  c = -1;
+	} else {
+	  c = instance.inputs.findIndex(x => x.Identifier === c);
+	}
+	// const d = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Name).value;
+	// console.log(`Current input index of ${d} is ${c}.`);
+	if (++c > n - 1) {
+	  c = 0;
+	}
+	// console.log(`Updated input index of ${d} to ${c}.`);
+	c = instance.inputs[c]?.Identifier;
+	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
+        return { ids: [service.uniqueId], status: 'SUCCESS', states: {currentInput: instance.inputs.find(x => x.Identifier === c).serviceName} };
+      }
+      case ('action.devices.commands.PreviousInput'): {
+	let c = service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).value as number;
+	let n = instance.inputs.length;
+	if (instance.channels.find(x => x.Identifier === c)) {
+	  c = -1;
+	} else {
+	  c = instance.inputs.findIndex(x => x.Identifier === c);
+	}
+	// const d = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Name).value;
+	// console.log(`Current input index of ${d} is ${c}.`);
+	if (--c < 0) {
+	  c = n - 1;
+	}
+	// console.log(`Updated input index of ${d} to ${c}.`);
+	c = instance.inputs[c]?.Identifier;
+	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.ActiveIdentifier).setValue(c);
+        return { ids: [service.uniqueId], status: 'SUCCESS', states: {currentInput: instance.inputs.find(x => x.Identifier === c).serviceName} };
+      }
+      // Characteristic.RemoteKey.REWIND = 0;
+      // Characteristic.RemoteKey.FAST_FORWARD = 1;
+      // Characteristic.RemoteKey.NEXT_TRACK = 2;
+      // Characteristic.RemoteKey.PREVIOUS_TRACK = 3;
+      // Characteristic.RemoteKey.ARROW_UP = 4;
+      // Characteristic.RemoteKey.ARROW_DOWN = 5;
+      // Characteristic.RemoteKey.ARROW_LEFT = 6;
+      // Characteristic.RemoteKey.ARROW_RIGHT = 7;
+      // Characteristic.RemoteKey.SELECT = 8;
+      // Characteristic.RemoteKey.BACK = 9;
+      // Characteristic.RemoteKey.EXIT = 10;
+      // Characteristic.RemoteKey.PLAY_PAUSE = 11;
+      // Characteristic.RemoteKey.INFORMATION = 15;
+      case ('action.devices.commands.mediaStop'): {
+	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(9) // Characteristic.RemoteKey.BACK,
+        return { ids: [service.uniqueId], status: 'SUCCESS' };
+      }
+      case ('action.devices.commands.mediaResume'): {
+	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(8); // Characteristic.RemoteKey.SELECT,
+        return { ids: [service.uniqueId], status: 'SUCCESS' };
+      }
+      case ('action.devices.commands.mediaPause'): {
+	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(11); // Characteristic.RemoteKey.PLAY_PAUSE,
+        return { ids: [service.uniqueId], status: 'SUCCESS' };
+      }
+      case ('action.devices.commands.mediaNext'): {
+	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(7); // Characteristic.RemoteKey.ARROW_RIGHT,
+        return { ids: [service.uniqueId], status: 'SUCCESS' };
+      }
+      case ('action.devices.commands.mediaPrevious'): {
+	await service.serviceCharacteristics.find(x => x.uuid === Characteristic.RemoteKey).setValue(6); // Characteristic.RemoteKey.ARROW_LEFT,
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       default: { return { ids: [service.uniqueId], status: 'ERROR', debugString: `unknown command ${command.execution[0].command}` }; }


### PR DESCRIPTION
## :recycle: Current situation

Only ON/OFF control is supported for television device.

## :bulb: Proposed solution

This PR implements television controls (input-source and channel selection, muting, remote-keys) ported from my PR to original repository (https://github.com/oznu/homebridge-gsh/pull/175). Seems no one has been interested in since then, it has been working every days more than years.

## :gear: Release Notes

Following traits are implemented.

action.devices.traits.Channel
action.devices.traits.InputSelector
action.devices.traits.Volume
action.devices.traits.TransportControl

Channels/Input-sources are identified using naming convention of homebridge-alexa. 

## :heavy_plus_sign: Additional Information

Unfortunately, oral control for channels were stopped working about a year ago. The request are annoyingly intercepted by Youtube music streaming. So I had to switch to input-source configuration. It might be due to my old device, I hope anyone would try to duplicate the issue and find the solution. 

### Testing

Channel, input-source. volume up/down. mute controls using Google app are confirmed to work.
Oral controls of Input-source, volume-up/down, channel-up/down are confirmed to work.

using custom homebridge-broadlink-rm plugin (https://github.com/banboobee/homebridge-broadlink-rm)

### Reviewer Nudging

Using Google app is a good way to confirm the implementation. Then confirm oral control for volume, mute, input-source, and finally channels.
