### PR TITLE
Implements OccupancySensing trait.

### DIFF
--- a/src/hap.ts
+++ b/src/hap.ts
@@ -21,6 +21,7 @@ import { LockMechanism } from './types/lock-mechanism';
 import { SecuritySystem } from './types/security-system';
 import { Switch } from './types/switch';
 import { Television } from './types/television';
+import { OccupancySensor } from './types/occupancy-sensor';
 import { TemperatureSensor } from './types/temperature-sensor';
 import { Thermostat } from './types/thermostat';
 import { Window } from './types/window';
@@ -64,6 +65,7 @@ export class Hap {
     WindowCovering: new WindowCovering(),
     Speaker: this.dummy,
     InputSource: this.dummy,
+    OccupancySensor: new OccupancySensor(),
   };
 
   /* event tracking */
@@ -95,6 +97,7 @@ export class Hap {
     Characteristic.SecuritySystemCurrentState,
     Characteristic.ActiveIdentifier,
     Characteristic.Mute,
+    Characteristic.OccupancyDetected,
   ];
 
   instanceBlacklist: Array<string> = [];

--- a/src/types/occupancy-sensor.spec.ts
+++ b/src/types/occupancy-sensor.spec.ts
@@ -1,0 +1,176 @@
+import { CharacteristicType, ServiceType } from '@homebridge/hap-client';
+import { OccupancySensor } from './occupancy-sensor';
+
+const occupancySensor = new OccupancySensor();
+
+describe('occupancySensor', () => {
+  describe('sync message', () => {
+    it('occupancySensor ', async () => {
+      const response: any = occupancySensor.sync(occupancySensorTemp);
+      expect(response).toBeDefined();
+      expect(response.type).toBe('action.devices.types.SENSOR');
+      expect(response.traits).toContain('action.devices.traits.OccupancySensing');
+      expect(response.traits).not.toContain('action.devices.traits.Brightness');
+      expect(response.traits).not.toContain('action.devices.traits.ColorSetting');
+      expect(response.attributes).toBeDefined();
+      expect(response.attributes.occupancySensorConfiguration).toBeDefined();
+      expect(response.attributes.occupancySensorConfiguration[0].occupancySensorType).toBe('PIR');
+      // await sleep(10000)
+    });
+  });
+  describe('query message', () => {
+    it('occupancySensor ', async () => {
+      const response = occupancySensor.query(occupancySensorTemp);
+      expect(response).toBeDefined();
+      expect(response.occupancy).toBeDefined();
+      expect(response.occupancy === 'OCCUPIED' || response.occupancy === 'UNOCCUPIED');
+      expect(response.online).toBeDefined();
+      // await sleep(10000)
+    });
+  });
+
+  describe('execute message', () => {
+    it('occupancySensor ', async () => {
+      const response = await occupancySensor.execute(occupancySensorTemp, commandOnOff);
+      expect(response).toBeDefined();
+      expect(response.ids).toBeDefined();
+      expect(response.status).toBe('ERROR');
+      // await sleep(10000)
+    });
+
+    it('occupancySensor  - commandMalformed', async () => {
+      const response = await occupancySensor.execute(occupancySensorTemp, commandMalformed);
+      expect(response).toBeDefined();
+      expect(response.ids).toBeDefined();
+      expect(response.status).toBe('ERROR');
+    });
+
+    it('occupancySensor  - commandIncorrectCommand', async () => {
+      const response = await occupancySensor.execute(occupancySensorTemp, commandIncorrectCommand);
+      expect(response).toBeDefined();
+      expect(response.ids).toBeDefined();
+      expect(response.status).toBe('ERROR');
+    });
+  });
+});
+
+async function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const occupancySensorTemp: ServiceType = {
+  'aid': 23,
+  'iid': 13,
+  'uuid': '00000086-0000-1000-8000-0026BB765291',
+  'type': 'OccupancySensor',
+  'humanType': 'Occupancy Sensor',
+  'serviceName': '',
+  'serviceCharacteristics': [
+    {
+      aid: 23,
+      iid: 15,
+      uuid: '00000071-0000-1000-8000-0026BB765291',
+      type: 'OccupancyDetected',
+      serviceType: 'OccupancySensor',
+      serviceName: '',
+      description: 'Occupancy Detected',
+      value: 0,
+      format: 'uint8',
+      perms: [
+        'ev',
+        'pr',
+      ],
+      maxValue: 1,
+      minValue: 0,
+      minStep: 1,
+      canRead: true,
+      canWrite: false,
+      ev: true,
+    },
+  ],
+  accessoryInformation: {
+    'Manufacturer': 'NRCHKB',
+    'Model': '1.4.3',
+    'Name': 'Backyard',
+    'Serial Number': 'Default Serial Number',
+    'Firmware Revision': '1.4.3',
+    'Hardware Revision': '1.4.3',
+    'Software Revision': '1.4.3',
+  },
+  'values': {
+    'OccupancyDetected': 0,
+  },
+  'instance': {
+    'name': 'Default Model',
+    'username': '69:62:B7:AE:38:D4',
+    'ipAddress': '192.168.1.11',
+    'port': 51830,
+    connectionFailedCount: 0,
+    services: [],
+    configurationNumber: 1,
+  },
+  'uniqueId': '4a1df9989d8d4e7b440455f15d9bdd5326d81f80ccfa753499899864a5248657',
+};
+
+const commandOnOff = {
+  devices: [
+    {
+      customData: {
+        aid: 75,
+        iid: 8,
+        instanceIpAddress: '192.168.1.11',
+        instancePort: 46283,
+        instanceUsername: '1C:22:3D:E3:CF:34',
+      },
+      id: 'b9245954ec41632a14076df3bbb7336f756c17ca4b040914a593e14d652d5738',
+    },
+  ],
+  execution: [
+    {
+      command: 'action.devices.commands.OnOff',
+      params: {
+        on: true,
+      },
+    },
+  ],
+};
+
+const commandMalformed = {
+  devices: [
+    {
+      customData: {
+        aid: 75,
+        iid: 8,
+        instanceIpAddress: '192.168.1.11',
+        instancePort: 46283,
+        instanceUsername: '1C:22:3D:E3:CF:34',
+      },
+      id: 'b9245954ec41632a14076df3bbb7336f756c17ca4b040914a593e14d652d5738',
+    },
+  ],
+  execution: [
+  ],
+};
+
+const commandIncorrectCommand = {
+  devices: [
+    {
+      customData: {
+        aid: 75,
+        iid: 8,
+        instanceIpAddress: '192.168.1.11',
+        instancePort: 46283,
+        instanceUsername: '1C:22:3D:E3:CF:34',
+      },
+      id: 'b9245954ec41632a14076df3bbb7336f756c17ca4b040914a593e14d652d5738',
+    },
+  ],
+  execution: [
+    {
+      command: 'action.devices.commands.notACommand',
+      params: {
+        on: true,
+      },
+    },
+  ],
+};

--- a/src/types/occupancy-sensor.ts
+++ b/src/types/occupancy-sensor.ts
@@ -1,0 +1,34 @@
+import { ServiceType } from '@homebridge/hap-client';
+import { SmartHomeV1ExecuteRequestCommands, SmartHomeV1ExecuteResponseCommands } from 'actions-on-google';
+import { Characteristic } from '../hap-types';
+import { ghToHap, ghToHap_t } from './ghToHapTypes';
+
+export class OccupancySensor extends ghToHap implements ghToHap_t {
+  sync(service: ServiceType) {
+    return this.createSyncData(service, {
+      type: 'action.devices.types.SENSOR',
+      traits: [
+        'action.devices.traits.OccupancySensing',
+      ],
+      attributes: {
+        occupancySensorConfiguration: [{
+          occupancySensorType: 'PIR',
+        }],
+      },
+    });
+  }
+
+  query(service: ServiceType) {
+    return {
+      online: true,
+      occupancy: service.serviceCharacteristics.find(x => x.uuid === Characteristic.OccupancyDetected)?.value ? 'OCCUPIED': 'UNOCCUPIED',
+    } as any;
+  }
+
+  async execute(service: ServiceType, command: SmartHomeV1ExecuteRequestCommands): Promise<SmartHomeV1ExecuteResponseCommands> {
+    if (!command.execution.length) {
+      return { ids: [service.uniqueId], status: 'ERROR', debugString: 'missing command' };
+    }
+    return { ids: [service.uniqueId], status: 'ERROR', debugString: `unknown command ${command.execution[0].command}` };
+  }
+}


### PR DESCRIPTION
## :recycle: Current situation

From the designing policy of plugin, the original did not support sensor type traits. But occupancy sensor service in Homekit has a matching trait in Google to support it. 

## :bulb: Proposed solution

Implements Occupancy sensor device.

## :gear: Release Notes

Occupancy sensor service of accessory will be exposed as a device in Google.

## :heavy_plus_sign: Additional Information

As in the original, sensing service support depends on the plugin policy. Reject if violates.

### Testing

The functions are confirmed in local environment. Unit test is also added.

### Reviewer Nudging

Try to expose occupancy sensors and see if they work.
