### PR TITLE
Implements ContactSensor using OpenClose trait.

### DIFF
--- a/src/hap.ts
+++ b/src/hap.ts
@@ -21,6 +21,7 @@ import { LockMechanism } from './types/lock-mechanism';
 import { SecuritySystem } from './types/security-system';
 import { Switch } from './types/switch';
 import { Television } from './types/television';
+import { ContactSensor } from './types/contact-sensor';
 import { TemperatureSensor } from './types/temperature-sensor';
 import { Thermostat } from './types/thermostat';
 import { Window } from './types/window';
@@ -64,6 +65,7 @@ export class Hap {
     WindowCovering: new WindowCovering(),
     Speaker: this.dummy,
     InputSource: this.dummy,
+    ContactSensor: new ContactSensor(),
   };
 
   /* event tracking */
@@ -95,6 +97,7 @@ export class Hap {
     Characteristic.SecuritySystemCurrentState,
     Characteristic.ActiveIdentifier,
     Characteristic.Mute,
+    Characteristic.ContactSensorState,
   ];
 
   instanceBlacklist: Array<string> = [];

--- a/src/types/contact-sensor.spec.ts
+++ b/src/types/contact-sensor.spec.ts
@@ -24,7 +24,8 @@ describe('contactSensor', () => {
       const response = contactSensor.query(contactSensorTemp);
       expect(response).toBeDefined();
       expect(response.openPercent).toBeDefined();
-      expect(response.openPercent === 0 || response.contact === 100);
+      expect(response.openPercent).toBe(0);
+      expect(response.openPercent).toBe(100);
       expect(response.online).toBeDefined();
       // await sleep(10000)
     });

--- a/src/types/contact-sensor.spec.ts
+++ b/src/types/contact-sensor.spec.ts
@@ -1,0 +1,177 @@
+import { CharacteristicType, ServiceType } from '@homebridge/hap-client';
+import { ContactSensor } from './contact-sensor';
+
+const contactSensor = new ContactSensor();
+
+describe('contactSensor', () => {
+  describe('sync message', () => {
+    it('contactSensor ', async () => {
+      const response: any = contactSensor.sync(contactSensorTemp);
+      expect(response).toBeDefined();
+      expect(response.type).toBe('action.devices.types.SENSOR');
+      expect(response.traits).toContain('action.devices.traits.OpenClose');
+      expect(response.traits).not.toContain('action.devices.traits.Brightness');
+      expect(response.traits).not.toContain('action.devices.traits.ColorSetting');
+      expect(response.attributes).toBeDefined();
+      expect(response.attributes.discreteOnlyOpenClose).toBe(true);
+      expect(response.attributes.openDirection).toBeDefined();
+      expect(response.attributes.queryOnlyOpenClose).toBe(true);
+      // await sleep(10000)
+    });
+  });
+  describe('query message', () => {
+    it('contactSensor ', async () => {
+      const response = contactSensor.query(contactSensorTemp);
+      expect(response).toBeDefined();
+      expect(response.openPercent).toBeDefined();
+      expect(response.openPercent === 0 || response.contact === 100);
+      expect(response.online).toBeDefined();
+      // await sleep(10000)
+    });
+  });
+
+  describe('execute message', () => {
+    it('contactSensor ', async () => {
+      const response = await contactSensor.execute(contactSensorTemp, commandOnOff);
+      expect(response).toBeDefined();
+      expect(response.ids).toBeDefined();
+      expect(response.status).toBe('ERROR');
+      // await sleep(10000)
+    });
+
+    it('contactSensor  - commandMalformed', async () => {
+      const response = await contactSensor.execute(contactSensorTemp, commandMalformed);
+      expect(response).toBeDefined();
+      expect(response.ids).toBeDefined();
+      expect(response.status).toBe('ERROR');
+    });
+
+    it('contactSensor  - commandIncorrectCommand', async () => {
+      const response = await contactSensor.execute(contactSensorTemp, commandIncorrectCommand);
+      expect(response).toBeDefined();
+      expect(response.ids).toBeDefined();
+      expect(response.status).toBe('ERROR');
+    });
+  });
+});
+
+async function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const contactSensorTemp: ServiceType = {
+  'aid': 23,
+  'iid': 13,
+  'uuid': '00000086-0000-1000-8000-0026BB765291',
+  'type': 'ContactSensor',
+  'humanType': 'Contact Sensor',
+  'serviceName': '',
+  'serviceCharacteristics': [
+    {
+      aid: 23,
+      iid: 13,
+      uuid: '0000006A-0000-1000-8000-0026BB765291',
+      type: 'ContactSensorState',
+      serviceType: 'ContactSensor',
+      serviceName: '',
+      description: 'Contact Sensor State',
+      value: 0,
+      format: 'uint8',
+      perms: [
+        'ev',
+        'pr',
+      ],
+      maxValue: 1,
+      minValue: 0,
+      minStep: 1,
+      canRead: true,
+      canWrite: false,
+      ev: true,
+    },
+  ],
+  accessoryInformation: {
+    'Manufacturer': 'NRCHKB',
+    'Model': '1.4.3',
+    'Name': 'Backyard',
+    'Serial Number': 'Default Serial Number',
+    'Firmware Revision': '1.4.3',
+    'Hardware Revision': '1.4.3',
+    'Software Revision': '1.4.3',
+  },
+  values: {
+    ContactSensorState: 0,
+  },
+  'instance': {
+    'name': 'Default Model',
+    'username': '69:62:B7:AE:38:D4',
+    'ipAddress': '192.168.1.11',
+    'port': 51830,
+    connectionFailedCount: 0,
+    services: [],
+    configurationNumber: 1,
+  },
+  'uniqueId': '4a1df9989d8d4e7b440455f15d9bdd5326d81f80ccfa753499899864a5248657',
+};
+
+const commandOnOff = {
+  devices: [
+    {
+      customData: {
+        aid: 75,
+        iid: 8,
+        instanceIpAddress: '192.168.1.11',
+        instancePort: 46283,
+        instanceUsername: '1C:22:3D:E3:CF:34',
+      },
+      id: 'b9245954ec41632a14076df3bbb7336f756c17ca4b040914a593e14d652d5738',
+    },
+  ],
+  execution: [
+    {
+      command: 'action.devices.commands.OnOff',
+      params: {
+        on: true,
+      },
+    },
+  ],
+};
+
+const commandMalformed = {
+  devices: [
+    {
+      customData: {
+        aid: 75,
+        iid: 8,
+        instanceIpAddress: '192.168.1.11',
+        instancePort: 46283,
+        instanceUsername: '1C:22:3D:E3:CF:34',
+      },
+      id: 'b9245954ec41632a14076df3bbb7336f756c17ca4b040914a593e14d652d5738',
+    },
+  ],
+  execution: [
+  ],
+};
+
+const commandIncorrectCommand = {
+  devices: [
+    {
+      customData: {
+        aid: 75,
+        iid: 8,
+        instanceIpAddress: '192.168.1.11',
+        instancePort: 46283,
+        instanceUsername: '1C:22:3D:E3:CF:34',
+      },
+      id: 'b9245954ec41632a14076df3bbb7336f756c17ca4b040914a593e14d652d5738',
+    },
+  ],
+  execution: [
+    {
+      command: 'action.devices.commands.notACommand',
+      params: {
+        on: true,
+      },
+    },
+  ],
+};

--- a/src/types/contact-sensor.ts
+++ b/src/types/contact-sensor.ts
@@ -1,0 +1,34 @@
+import { ServiceType } from '@homebridge/hap-client';
+import { SmartHomeV1ExecuteRequestCommands, SmartHomeV1ExecuteResponseCommands } from 'actions-on-google';
+import { Characteristic } from '../hap-types';
+import { ghToHap, ghToHap_t } from './ghToHapTypes';
+
+export class ContactSensor extends ghToHap implements ghToHap_t {
+  sync(service: ServiceType) {
+    return this.createSyncData(service, {
+      type: 'action.devices.types.SENSOR',
+      traits: [
+        'action.devices.traits.OpenClose',
+      ],
+      attributes: {
+        discreteOnlyOpenClose: true,
+        openDirection: ['LEFT', 'RIGHT'],
+        queryOnlyOpenClose: true,
+      },
+    });
+  }
+
+  query(service: ServiceType) {
+    return {
+      online: true,
+      openPercent: service.serviceCharacteristics.find(x => x.uuid === Characteristic.ContactSensorState)?.value ? 100: 0,
+    } as any;
+  }
+
+  async execute(service: ServiceType, command: SmartHomeV1ExecuteRequestCommands): Promise<SmartHomeV1ExecuteResponseCommands> {
+    if (!command.execution.length) {
+      return { ids: [service.uniqueId], status: 'ERROR', debugString: 'missing command' };
+    }
+    return { ids: [service.uniqueId], status: 'ERROR', debugString: `unknown command ${command.execution[0].command}` };
+  }
+}


### PR DESCRIPTION
## :recycle: Current situation

As in #24, the original did not support sensor type traits. But google document describes that OpenClose trait is also applicable  for sensor type device.

https://developers.home.google.com/cloud-to-cloud/guides/sensor

## :bulb: Proposed solution

Implements Contact sensor device using OpenClose trait.

## :gear: Release Notes

Contact sensor service of accessory will be exposed as a device in Google.

## :heavy_plus_sign: Additional Information

As in #24, reject if violates plugin policy.

### Testing

The functions are confirmed in local environment. Unit test is also added.

### Reviewer Nudging

Try to expose contact sensors and see if they work.
