### PR TITLE
Enables instanceDenylist.

### DIFF
--- a/src/hap.ts
+++ b/src/hap.ts
@@ -333,6 +333,7 @@ export class Hap {
       }
       services = services.filter(x => this.types[x.type] !== undefined);
       this.log.debug(`Loaded ${services.length} accessories from Homebridge - pre filter`);
+      services = services.filter(x => !this.instanceBlacklist.find(y => y === x?.instance?.username));
       // Pre-compile accessoryFilter strings into RegExp objects
       const compiledAccessoryFilter = this.accessoryFilter.map(filter => new RegExp(filter));
       const searchList = (target: string, regexList: RegExp[]): boolean => {


### PR DESCRIPTION
## :recycle: Current situation

Overlooked instanceDenylist is not yet implemented. Should be included in #23.

## :bulb: Proposed solution

Implement instanceDenylist 

## :gear: Release Notes

Implemented instanceDenylist 

## :heavy_plus_sign: Additional Information

### Testing

Confirmed that the accessories of specified homebridge instance are filtered out. 

### Reviewer Nudging

Add instanceDenylist to config to try.
