### PR TITLE
SWITCH type device to include brightness trait.

### DIFF
--- a/src/types/switch.spec.ts
+++ b/src/types/switch.spec.ts
@@ -15,6 +15,16 @@ describe('switch', () => {
       expect(response.attributes).not.toBeDefined();
       // await sleep(10000)
     });
+    it('switch with Brightness', async () => {
+      const response: any = switchDevice.sync(switchDeviceServiceHue);
+      expect(response).toBeDefined();
+      expect(response.type).toBe('action.devices.types.SWITCH');
+      expect(response.traits).toContain('action.devices.traits.OnOff');
+      expect(response.traits).toContain('action.devices.traits.Brightness');
+      expect(response.traits).not.toContain('action.devices.traits.ColorSetting');
+      expect(response.attributes).not.toBeDefined();
+      // await sleep(10000)
+    });
   });
   describe('query message', () => {
     it('switch with On/Off only', async () => {
@@ -24,11 +34,27 @@ describe('switch', () => {
       expect(response.online).toBeDefined();
       // await sleep(10000)
     });
+    it('switch with Brightness', async () => {
+      const response = switchDevice.query(switchDeviceServiceHue);
+      expect(response).toBeDefined();
+      expect(response.on).toBeDefined();
+      expect(response.brightness).toBeDefined();
+      expect(response.online).toBeDefined();
+      // await sleep(10000)
+    });
   });
 
   describe('execute message', () => {
     it('switch with On/Off only', async () => {
       const response = await switchDevice.execute(switchDeviceServiceOnOff, commandOnOff);
+      expect(response).toBeDefined();
+      expect(response.ids).toBeDefined();
+      expect(response.status).toBe('SUCCESS');
+      // await sleep(10000)
+    });
+
+    it('switch with Brightness', async () => {
+      const response = await switchDevice.execute(switchDeviceServiceHue, commandBrightness);
       expect(response).toBeDefined();
       expect(response.ids).toBeDefined();
       expect(response.status).toBe('SUCCESS');
@@ -602,12 +628,20 @@ const commandBrightness = {
   ],
   execution: [
     {
-      command: 'action.devices.commands.OnOff',
+      command: 'action.devices.commands.BrightnessAbsolute',
       params: {
-        on: true,
+        brightness: 1,
       },
     },
   ],
+  // execution: [
+  //   {
+  //     command: 'action.devices.commands.OnOff',
+  //     params: {
+  //       on: true,
+  //     },
+  //   },
+  // ],
 };
 
 const commandColorHSV = {

--- a/src/types/switch.spec.ts
+++ b/src/types/switch.spec.ts
@@ -634,14 +634,7 @@ const commandBrightness = {
       },
     },
   ],
-  // execution: [
-  //   {
-  //     command: 'action.devices.commands.OnOff',
-  //     params: {
-  //       on: true,
-  //     },
-  //   },
-  // ],
+// Removed commented-out code block for maintainability.
 };
 
 const commandColorHSV = {

--- a/src/types/switch.ts
+++ b/src/types/switch.ts
@@ -36,7 +36,7 @@ export class Switch extends ghToHap implements ghToHap_t {
 
     // check if the switch has the brightness characteristic
     if (service.type === 'Switch' &&
-	service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness)) {
+    service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness)) {
       response.brightness = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness).value;
     }
 

--- a/src/types/switch.ts
+++ b/src/types/switch.ts
@@ -53,7 +53,11 @@ export class Switch extends ghToHap implements ghToHap_t {
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       case ('action.devices.commands.BrightnessAbsolute'): {
-        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness).setValue(command.execution[0].params.brightness);
+        const brightnessCharacteristic = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness);
+        if (!brightnessCharacteristic) {
+          return { ids: [service.uniqueId], status: 'ERROR', debugString: 'Brightness characteristic not found' };
+        }
+        await brightnessCharacteristic.setValue(command.execution[0].params.brightness);
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       default: { return { ids: [service.uniqueId], status: 'ERROR', debugString: `unknown command ${command.execution[0].command}` }; }

--- a/src/types/switch.ts
+++ b/src/types/switch.ts
@@ -18,7 +18,7 @@ export class Switch extends ghToHap implements ghToHap_t {
 
     // check if the switch has the brightness characteristic
     if (service.type === 'Switch' &&
-	service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness)) {
+    service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness)) {
       traits.push('action.devices.traits.Brightness');
     }
 

--- a/src/types/switch.ts
+++ b/src/types/switch.ts
@@ -17,8 +17,8 @@ export class Switch extends ghToHap implements ghToHap_t {
     ];
 
     // check if the switch has the brightness characteristic
-    if (service.type === 'Switch' &&
-    service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness)) {
+    const brightnessCharacteristic = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness);
+    if (service.type === 'Switch' && brightnessCharacteristic) {
       traits.push('action.devices.traits.Brightness');
     }
 

--- a/src/types/switch.ts
+++ b/src/types/switch.ts
@@ -12,19 +12,35 @@ export class Switch extends ghToHap implements ghToHap_t {
   }
 
   sync(service: ServiceType) {
+    const traits = [
+      'action.devices.traits.OnOff',
+    ];
+
+    // check if the switch has the brightness characteristic
+    if (service.type === 'Switch' &&
+	service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness)) {
+      traits.push('action.devices.traits.Brightness');
+    }
+
     return this.createSyncData(service, {
       type: this.deviceType,
-      traits: [
-        'action.devices.traits.OnOff',
-      ],
+      traits,
     });
   }
 
   query(service: ServiceType) {
-    return {
+    const response = {
       on: !!service.serviceCharacteristics.find(x => x.uuid === Characteristic.On).value,
       online: true,
-    };
+    } as any;
+
+    // check if the switch has the brightness characteristic
+    if (service.type === 'Switch' &&
+	service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness)) {
+      response.brightness = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness).value;
+    }
+
+    return response;
   }
 
   async execute(service: ServiceType, command: SmartHomeV1ExecuteRequestCommands): Promise<SmartHomeV1ExecuteResponseCommands> {
@@ -34,6 +50,10 @@ export class Switch extends ghToHap implements ghToHap_t {
     switch (command.execution[0].command) {
       case ('action.devices.commands.OnOff'): {
         await service.serviceCharacteristics.find(x => x.uuid === Characteristic.On).setValue(command.execution[0].params.on);
+        return { ids: [service.uniqueId], status: 'SUCCESS' };
+      }
+      case ('action.devices.commands.BrightnessAbsolute'): {
+        await service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness).setValue(command.execution[0].params.brightness);
         return { ids: [service.uniqueId], status: 'SUCCESS' };
       }
       default: { return { ids: [service.uniqueId], status: 'ERROR', debugString: `unknown command ${command.execution[0].command}` }; }

--- a/src/types/switch.ts
+++ b/src/types/switch.ts
@@ -35,9 +35,9 @@ export class Switch extends ghToHap implements ghToHap_t {
     } as any;
 
     // check if the switch has the brightness characteristic
-    if (service.type === 'Switch' &&
-    service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness)) {
-      response.brightness = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness).value;
+    const brightnessCharacteristic = service.serviceCharacteristics.find(x => x.uuid === Characteristic.Brightness);
+    if (service.type === 'Switch' && brightnessCharacteristic) {
+      response.brightness = brightnessCharacteristic.value;
     }
 
     return response;


### PR DESCRIPTION
## :recycle: Current situation

SWITCH type device can include Brightness trait.

https://developers.home.google.com/cloud-to-cloud/guides/switch

## :bulb: Proposed solution

SWITCH device to include brightness trait if the characteristic is available.

## :gear: Release Notes

Slider control of SWITCH device will appear if the accessory has brightness characteristic.

## :heavy_plus_sign: Additional Information

### Testing

Revised/added test cases for SWITCH device.

### Reviewer Nudging


